### PR TITLE
Avoid resetting simulation when toggling heightmap visualization

### DIFF
--- a/Source/PlanetaryCreationEditor/Private/SPTectonicToolPanel.cpp
+++ b/Source/PlanetaryCreationEditor/Private/SPTectonicToolPanel.cpp
@@ -727,10 +727,9 @@ void SPTectonicToolPanel::OnHeightmapVisualizationChanged(ECheckBoxState NewStat
     {
         if (UTectonicSimulationService* Service = Controller->GetSimulationService())
         {
-            FTectonicSimulationParameters Params = Service->GetParameters();
-            Params.bEnableHeightmapVisualization = (NewState == ECheckBoxState::Checked);
-            Service->SetParameters(Params);
-            UE_LOG(LogTemp, Log, TEXT("Heightmap visualization %s"), Params.bEnableHeightmapVisualization ? TEXT("enabled") : TEXT("disabled"));
+            const bool bEnabled = (NewState == ECheckBoxState::Checked);
+            Service->SetHeightmapVisualizationEnabled(bEnabled);
+            UE_LOG(LogTemp, Log, TEXT("Heightmap visualization %s"), bEnabled ? TEXT("enabled") : TEXT("disabled"));
 
             // Trigger mesh refresh to apply new coloring immediately
             Controller->RebuildPreview();

--- a/Source/PlanetaryCreationEditor/Private/TectonicSimulationService.cpp
+++ b/Source/PlanetaryCreationEditor/Private/TectonicSimulationService.cpp
@@ -263,6 +263,18 @@ void UTectonicSimulationService::AdvanceSteps(int32 StepCount)
 
 void UTectonicSimulationService::SetParameters(const FTectonicSimulationParameters& NewParams)
 {
+    if (Parameters.bEnableHeightmapVisualization != NewParams.bEnableHeightmapVisualization)
+    {
+        FTectonicSimulationParameters ComparableParams = NewParams;
+        ComparableParams.bEnableHeightmapVisualization = Parameters.bEnableHeightmapVisualization;
+
+        if (FMemory::Memcmp(&ComparableParams, &Parameters, sizeof(FTectonicSimulationParameters)) == 0)
+        {
+            SetHeightmapVisualizationEnabled(NewParams.bEnableHeightmapVisualization);
+            return;
+        }
+    }
+
     Parameters = NewParams;
 
     // M5 Phase 3: Validate and clamp PlanetRadius to prevent invalid simulations
@@ -277,6 +289,22 @@ void UTectonicSimulationService::SetParameters(const FTectonicSimulationParamete
     }
 
     ResetSimulation();
+}
+
+void UTectonicSimulationService::SetHeightmapVisualizationEnabled(bool bEnabled)
+{
+    if (Parameters.bEnableHeightmapVisualization == bEnabled)
+    {
+        return;
+    }
+
+    Parameters.bEnableHeightmapVisualization = bEnabled;
+
+    // Increment surface data version so cached LODs rebuild with updated vertex colors.
+    SurfaceDataVersion++;
+
+    UE_LOG(LogTemp, Log, TEXT("[Visualization] Heightmap visualization %s (SurfaceVersion=%d)"),
+        bEnabled ? TEXT("enabled") : TEXT("disabled"), SurfaceDataVersion);
 }
 
 void UTectonicSimulationService::SetRenderSubdivisionLevel(int32 NewLevel)

--- a/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
+++ b/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
@@ -678,6 +678,13 @@ public:
     void SetParameters(const FTectonicSimulationParameters& NewParams);
 
     /**
+     * Milestone 6 Task 2.3: Toggle heightmap visualization without resetting simulation state.
+     * Updates cached parameters, bumps surface version for LOD cache invalidation,
+     * and leaves tectonic history untouched.
+     */
+    void SetHeightmapVisualizationEnabled(bool bEnabled);
+
+    /**
      * Milestone 4 Phase 4.1: Update render subdivision level without resetting simulation state.
      * This allows LOD changes during camera movement without destroying tectonic history.
      * Only regenerates render mesh and Voronoi mapping; preserves plates, stress, rifts, etc.


### PR DESCRIPTION
## Summary
- add a dedicated service API to toggle heightmap visualization without resetting the tectonic simulation
- bypass ResetSimulation when SetParameters is called with only a heightmap visualization change
- update the tectonic tool panel to use the new API and rebuild the preview immediately

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b070288c8332bd5e85ef212885ac