### PR TITLE
Handle visualization toggles without resetting simulation

### DIFF
--- a/Source/PlanetaryCreationEditor/Private/SPTectonicToolPanel.cpp
+++ b/Source/PlanetaryCreationEditor/Private/SPTectonicToolPanel.cpp
@@ -701,10 +701,9 @@ void SPTectonicToolPanel::OnAutomaticLODChanged(ECheckBoxState NewState)
     {
         if (UTectonicSimulationService* Service = Controller->GetSimulationService())
         {
-            FTectonicSimulationParameters Params = Service->GetParameters();
-            Params.bEnableAutomaticLOD = (NewState == ECheckBoxState::Checked);
-            Service->SetParameters(Params);
-            UE_LOG(LogTemp, Log, TEXT("Automatic LOD %s"), Params.bEnableAutomaticLOD ? TEXT("enabled") : TEXT("disabled"));
+            const bool bEnabled = (NewState == ECheckBoxState::Checked);
+            Service->SetAutomaticLODEnabled(bEnabled);
+            UE_LOG(LogTemp, Log, TEXT("Automatic LOD %s"), bEnabled ? TEXT("enabled") : TEXT("disabled"));
         }
     }
 }
@@ -727,10 +726,9 @@ void SPTectonicToolPanel::OnHeightmapVisualizationChanged(ECheckBoxState NewStat
     {
         if (UTectonicSimulationService* Service = Controller->GetSimulationService())
         {
-            FTectonicSimulationParameters Params = Service->GetParameters();
-            Params.bEnableHeightmapVisualization = (NewState == ECheckBoxState::Checked);
-            Service->SetParameters(Params);
-            UE_LOG(LogTemp, Log, TEXT("Heightmap visualization %s"), Params.bEnableHeightmapVisualization ? TEXT("enabled") : TEXT("disabled"));
+            const bool bEnabled = (NewState == ECheckBoxState::Checked);
+            Service->SetHeightmapVisualizationEnabled(bEnabled);
+            UE_LOG(LogTemp, Log, TEXT("Heightmap visualization %s"), bEnabled ? TEXT("enabled") : TEXT("disabled"));
 
             // Trigger mesh refresh to apply new coloring immediately
             Controller->RebuildPreview();

--- a/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
+++ b/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
@@ -678,6 +678,16 @@ public:
     void SetParameters(const FTectonicSimulationParameters& NewParams);
 
     /**
+     * Milestone 6 Task 2.3: Toggle heightmap visualization without resetting simulation state.
+     * Updates cached parameters, bumps surface version for LOD cache invalidation,
+     * and leaves tectonic history untouched.
+     */
+    void SetHeightmapVisualizationEnabled(bool bEnabled);
+
+    /** Toggle automatic LOD control without resetting the simulation. */
+    void SetAutomaticLODEnabled(bool bEnabled);
+
+    /**
      * Milestone 4 Phase 4.1: Update render subdivision level without resetting simulation state.
      * This allows LOD changes during camera movement without destroying tectonic history.
      * Only regenerates render mesh and Voronoi mapping; preserves plates, stress, rifts, etc.


### PR DESCRIPTION
## Summary
- extend the parameter diff check so heightmap and automatic LOD toggles no longer trigger ResetSimulation
- add a SetAutomaticLODEnabled helper and switch the tool panel checkbox to call it directly
- move the per-step surface version bump to immediately before snapshotting so cached heightmap surfaces refresh after playback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2b070288c8332bd5e85ef212885ac