### PR TITLE
Add automatic LOD toggle to simulation service

### DIFF
--- a/Source/PlanetaryCreationEditor/Private/TectonicSimulationService.cpp
+++ b/Source/PlanetaryCreationEditor/Private/TectonicSimulationService.cpp
@@ -341,6 +341,18 @@ void UTectonicSimulationService::SetRenderSubdivisionLevel(int32 NewLevel)
         NewLevel, RenderVertices.Num(), RenderTriangles.Num() / 3);
 }
 
+void UTectonicSimulationService::SetAutomaticLODEnabled(bool bEnabled)
+{
+    if (Parameters.bEnableAutomaticLOD == bEnabled)
+    {
+        return;
+    }
+
+    Parameters.bEnableAutomaticLOD = bEnabled;
+
+    UE_LOG(LogTemp, Log, TEXT("[LOD] Automatic LOD %s"), bEnabled ? TEXT("enabled") : TEXT("disabled"));
+}
+
 void UTectonicSimulationService::GenerateDefaultSphereSamples()
 {
     BaseSphereSamples.Reset();

--- a/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
+++ b/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
@@ -691,6 +691,9 @@ public:
      */
     void SetRenderSubdivisionLevel(int32 NewLevel);
 
+    /** Milestone 4 Phase 4.1: Toggle automatic LOD selection without touching simulation history. */
+    void SetAutomaticLODEnabled(bool bEnabled);
+
     /** Export current simulation metrics to CSV (Milestone 2 - Phase 4). */
     void ExportMetricsToCSV();
 


### PR DESCRIPTION
## Summary
- add a SetAutomaticLODEnabled editor subsystem API so the tool panel toggle compiles again
- log when automatic LOD is enabled or disabled without disturbing simulation history

## Testing
- not run (not supported in container)


------
https://chatgpt.com/codex/tasks/task_e_68e2bacdb12883329f687786ebf26f27