### PR TITLE
Preserve elevations during retessellation rebuild

### DIFF
--- a/Source/PlanetaryCreationEditor/Private/RetessellationPOC.cpp
+++ b/Source/PlanetaryCreationEditor/Private/RetessellationPOC.cpp
@@ -178,6 +178,11 @@ bool UTectonicSimulationService::PerformRetessellation()
     // Step 1: Create snapshot for rollback
     const FRetessellationSnapshot Snapshot = CaptureRetessellationSnapshot();
 
+    // Preserve previous render mesh positions and elevation data for transfer to the rebuilt mesh
+    const TArray<FVector3d> OldRenderVertices = RenderVertices;
+    const TArray<double> OldElevationValues = VertexElevationValues;
+    const TArray<double> OldAmplifiedElevation = VertexAmplifiedElevation;
+
     // Step 2: Detect drifted plates using real drift calculation
     TArray<int32> DriftedPlateIDs;
 
@@ -222,6 +227,9 @@ bool UTectonicSimulationService::PerformRetessellation()
     // Trigger full mesh regeneration
     GenerateRenderMesh();
     BuildVoronoiMapping();
+
+    // Reproject historic elevation field onto the regenerated mesh before type-based corrections run
+    TransferElevationFromPreviousMesh(OldRenderVertices, OldElevationValues, OldAmplifiedElevation);
 
     // Milestone 6 Fix: Refresh elevation baselines to match new plate assignments after retessellation
     // When Voronoi remaps vertices to different plates, elevation must update to reflect new crust type

--- a/Source/PlanetaryCreationEditor/Public/SphericalKDTree.h
+++ b/Source/PlanetaryCreationEditor/Public/SphericalKDTree.h
@@ -9,14 +9,23 @@
 class FSphericalKDTree
 {
 public:
-	/** Build tree from plate centroids with associated IDs. */
-	void Build(const TArray<FVector3d>& Points, const TArray<int32>& PointIDs);
+        /** Build tree from plate centroids with associated IDs. */
+        void Build(const TArray<FVector3d>& Points, const TArray<int32>& PointIDs);
 
-	/** Find the closest point to the query, returns the associated ID. */
-	int32 FindNearest(const FVector3d& Query, double& OutDistanceSq) const;
+        /** Find the closest point to the query, returns the associated ID. */
+        int32 FindNearest(const FVector3d& Query, double& OutDistanceSq) const;
 
-	/** Clear the tree. */
-	void Clear();
+        /**
+         * Find the K nearest neighbors to the query point.
+         * @param Query Point to query in unit sphere coordinates.
+         * @param K Number of neighbors to gather (clamped to point count).
+         * @param OutIDs Filled with point IDs sorted by ascending distance.
+         * @param OutDistancesSq Optional distances squared corresponding to OutIDs.
+         */
+        void FindKNearest(const FVector3d& Query, int32 K, TArray<int32>& OutIDs, TArray<double>* OutDistancesSq = nullptr) const;
+
+        /** Clear the tree. */
+        void Clear();
 
 	/** Check if tree is built. */
 	bool IsValid() const { return RootNode != nullptr; }
@@ -36,6 +45,9 @@ private:
 	/** Recursive tree build. */
 	TUniquePtr<FKDNode> BuildRecursive(TArray<TPair<FVector3d, int32>>& Points, int32 Depth);
 
-	/** Recursive nearest neighbor search. */
-	void FindNearestRecursive(const FKDNode* Node, const FVector3d& Query, int32& BestID, double& BestDistSq) const;
+        /** Recursive nearest neighbor search. */
+        void FindNearestRecursive(const FKDNode* Node, const FVector3d& Query, int32& BestID, double& BestDistSq) const;
+
+        /** Recursive K-nearest neighbor search. */
+        void FindKNearestRecursive(const FKDNode* Node, const FVector3d& Query, int32 K, TArray<TPair<double, int32>>& Best) const;
 };

--- a/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
+++ b/Source/PlanetaryCreationEditor/Public/TectonicSimulationService.h
@@ -905,6 +905,9 @@ private:
     /** Milestone 3 Task 2.1: Build Voronoi mapping from render vertices to plates. */
     void BuildVoronoiMapping();
 
+    /** Transfer pre-retessellation elevation data onto regenerated render mesh. */
+    void TransferElevationFromPreviousMesh(const TArray<FVector3d>& OldVertices, const TArray<double>& OldElevations, const TArray<double>& OldAmplifiedElevations);
+
     /** Milestone 3 Task 2.2: Compute per-vertex velocity field (v = ω × r). */
     void ComputeVelocityField();
 


### PR DESCRIPTION
## Summary
- capture the previous render mesh and reproject stored elevation/amplified data onto the regenerated vertices during retessellation
- add a reusable transfer helper on the simulation service that performs inverse-distance weighting against the spherical KD-tree
- extend the spherical KD-tree with a k-nearest query needed for elevation interpolation

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e2c8fa7d8c8332918bdcf40bec3af0